### PR TITLE
fix: 记忆录入(memory_record)在app端显示重复

### DIFF
--- a/aion-chat/routes/chat.py
+++ b/aion-chat/routes/chat.py
@@ -547,7 +547,6 @@ async def edit_resend_message(msg_id: str, body: MsgEditResend):
                         await manager.broadcast({"type": "memory_added", "data": mem_data})
                         mr_data = {'type': 'memory_record', 'msg_id': ai_msg_id, 'content': mem_content, 'mem_id': mem_id}
                         await _q.put(mr_data)
-                        await manager.broadcast({"type": "memory_record", "data": mr_data})
 
             full_text = META_TAG_PATTERN.sub("", full_text).strip()
 
@@ -1025,7 +1024,6 @@ async def send_message(conv_id: str, body: MsgCreate):
                         await manager.broadcast({"type": "memory_added", "data": mem_data})
                         mr_data = {'type': 'memory_record', 'msg_id': ai_msg_id, 'content': mem_content, 'mem_id': mem_id}
                         await _q.put(mr_data)
-                        await manager.broadcast({"type": "memory_record", "data": mr_data})
                         print(f"[MEMORY] AI 主动录入记忆: {mem_content[:50]}")
 
 
@@ -1806,7 +1804,6 @@ async def regenerate_message(conv_id: str, context_limit: int = 30, whisper_mode
                         await manager.broadcast({"type": "memory_added", "data": mem_data})
                         mr_data = {'type': 'memory_record', 'msg_id': ai_msg_id, 'content': mem_content, 'mem_id': mem_id}
                         await _q.put(mr_data)
-                        await manager.broadcast({"type": "memory_record", "data": mr_data})
                         print(f"[MEMORY] AI 主动录入记忆: {mem_content[:50]}")
 
             # 清洗 AI 回复中模仿产生的 <meta> 标签


### PR DESCRIPTION
修复 bot 主动写入记忆库时，前端记忆提示内容重复显示的问题

- 原因：`memory_record` 事件同时通过 SSE 队列和 WebSocket broadcast 双通道推送，前端 `showMemoryRecordHint` 以 `+=` 拼接内容，导致同一条记忆被追加多次
- 移除 `send_message`、`edit_resend_message`、`regenerate_message` 三处多余的 `manager.broadcast({"type": "memory_record", ...})`，SSE 队列已足够向请求客户端推送该事件

## 影响范围

仅删除 3 行重复广播，不影响 `memory_added` 广播（记忆页面实时更新仍正常）。

## Test plan

- [ ] 发送消息触发 bot 主动录入记忆（[MEMORY:xxx]），确认记忆提示只显示一次
- [ ] 编辑重发 / 重新生成场景同样验证
- [ ] 记忆管理页面仍能实时收到新记忆通知
